### PR TITLE
fix/iOS: check if the Sessions is not disconnected when fetching the web page

### DIFF
--- a/SafeMobileBrowser/SafeMobileBrowser/WebFetchImplementation/WebFetchService.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/WebFetchImplementation/WebFetchService.cs
@@ -18,7 +18,7 @@ namespace SafeMobileBrowser.WebFetchImplementation
             {
                 if (App.AppSession.IsDisconnected)
                 {
-                    throw new WebFetchException(ErrorConstants.SessionNotAvailableMsg);
+                    throw new WebFetchException(ErrorConstants.ConnectionFailedMsg);
                 }
 
                 return await webFetch.FetchAsync(url, options);

--- a/SafeMobileBrowser/SafeMobileBrowser/WebFetchImplementation/WebFetchService.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/WebFetchImplementation/WebFetchService.cs
@@ -16,6 +16,11 @@ namespace SafeMobileBrowser.WebFetchImplementation
         {
             try
             {
+                if (App.AppSession.IsDisconnected)
+                {
+                    throw new WebFetchException(ErrorConstants.SessionNotAvailableMsg);
+                }
+
                 return await webFetch.FetchAsync(url, options);
             }
             catch (WebFetchException ex)


### PR DESCRIPTION
Related to #141.

When the internet connection is changed the session should fire a disconnected event. Sometimes, native lib doesn't raise a disconnect event as soon as the network is changed and it takes some time to convey that the session is not active.

This PR will reduce the no of chance that this issue will re-occur and instead of freezing the app it will show an error page. PR doesn't solve the problem completely. 