### PR TITLE
fix(page reload): refactored code to show error pages from webfetch

### DIFF
--- a/SafeMobileBrowser/SafeMobileBrowser/Helpers/ErrorConstants.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/Helpers/ErrorConstants.cs
@@ -2,6 +2,10 @@
 {
     public static class ErrorConstants
     {
+        public const int SessionNotAvailableError = 100;
+        public const int ConnectionFailedError = 101;
+        public const int NoInternetConnectionError = 102;
+
         public const string SessionNotAvailable = "SessionNotAvailable";
         public const string InvalidUrl = "InvalidUrl";
         public const string NoInternetConnection = "NoInternetConnection";

--- a/SafeMobileBrowser/SafeMobileBrowser/ViewModels/HomePageViewModel.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/ViewModels/HomePageViewModel.cs
@@ -261,21 +261,8 @@ namespace SafeMobileBrowser.ViewModels
                     return;
 
                 SetAddressBarText(url);
-                url = AddressbarText;
 
-                if (!App.IsConnectedToInternet)
-                {
-                    TriggerErrorState(ErrorConstants.NoInternetConnection);
-                    return;
-                }
-
-                if (!IsSessionAvailable)
-                {
-                    TriggerErrorState(ErrorConstants.SessionNotAvailable);
-                    return;
-                }
-
-                url = Device.RuntimePlatform == Device.iOS ? $"safe://{url}" : $"https://{url}";
+                url = Device.RuntimePlatform == Device.iOS ? $"safe://{AddressbarText}" : $"https://{AddressbarText}";
 
                 if (!IsValidUri(url))
                     return;

--- a/SafeMobileBrowser/SafeMobileBrowser/Views/HomePage.xaml.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/Views/HomePage.xaml.cs
@@ -122,12 +122,8 @@ namespace SafeMobileBrowser.Views
             {
                 case ErrorConstants.InvalidUrl:
                     return (ErrorConstants.InvalidUrlTitle, ErrorConstants.InvalidUrlMsg);
-                case ErrorConstants.SessionNotAvailable:
-                    return (ErrorConstants.SessionNotAvailableTitle, ErrorConstants.SessionNotAvailableMsg);
-                case ErrorConstants.NoInternetConnection:
-                    return (ErrorConstants.NoInternetConnectionTitle, ErrorConstants.NoInternetConnectionMsg);
                 default:
-                    return (ErrorConstants.NoInternetConnectionTitle, ErrorConstants.NoInternetConnectionMsg);
+                    return (ErrorConstants.ErrorOccured, ErrorConstants.UnableToFetchDataMsg);
             }
         }
 


### PR DESCRIPTION
fixes: #117

Previously we were loading a new HTML page in webview to show error(s), now instead of loading a new page we are returning error page that way whenever a user tries to reload a page it will update the content without adding a new page in the navigation stack.