### PR TITLE
fix(iOS): update info.plist to allow photo download from webpage

### DIFF
--- a/SafeMobileBrowser/SafeMobileBrowser.iOS/Info.plist
+++ b/SafeMobileBrowser/SafeMobileBrowser.iOS/Info.plist
@@ -70,5 +70,7 @@
 	</dict>
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.1</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Mobile browser need to access to the photo library</string>
 </dict>
 </plist>

--- a/SafeMobileBrowser/SafeMobileBrowser.iOS/Info.plist
+++ b/SafeMobileBrowser/SafeMobileBrowser.iOS/Info.plist
@@ -71,6 +71,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.1</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Mobile browser need to access to the photo library</string>
+	<string>Mobile browser needs access to the photo library to download/upload image(s).</string>
 </dict>
 </plist>


### PR DESCRIPTION
fixes: #125 

It has a permission issue. Updated now.

_**Note:** Android still doesn't have a download option for image and may need some research to make that available._
