### PR TITLE
fix: bookmarks page 'no bookmarks text'

### DIFF
--- a/SafeMobileBrowser/SafeMobileBrowser/Views/BookmarksModalPage.xaml
+++ b/SafeMobileBrowser/SafeMobileBrowser/Views/BookmarksModalPage.xaml
@@ -43,6 +43,17 @@
             <Setter Property="VerticalOptions"
                     Value="Center" />
         </Style>
+        <Style x:Key="EmptyViewLabelStyle"
+               TargetType="Label">
+            <Setter Property="TextColor"
+                    Value="{StaticResource GreySmokeMediumColor}" />
+            <Setter Property="Text"
+                    Value="No Bookmarks" />
+            <Setter Property="HorizontalOptions"
+                    Value="Center" />
+            <Setter Property="VerticalOptions"
+                    Value="Center" />
+        </Style>
     </ContentPage.Resources>
     <ContentPage.Content>
         <StackLayout>
@@ -68,10 +79,7 @@
                             SelectedItem="{Binding SelectedBookmarkItem, Mode=TwoWay}"
                             ItemsSource="{Binding Bookmarks}">
                 <CollectionView.EmptyView>
-                    <Label HorizontalOptions="Center"
-                           VerticalOptions="Center"
-                           Text="No bookmarks!" 
-                           TextColor="{DynamicResource PrimaryTextColor}"/>
+                    <Label Style="{StaticResource EmptyViewLabelStyle}" />
                 </CollectionView.EmptyView>
                 <CollectionView.ItemTemplate>
                     <DataTemplate>


### PR DESCRIPTION
fixes: #14 
The 'no bookmarks` text when there was no bookmarks in the bookmarks modal page did not change text color when theme was changed as it was not getting updated in run time and hence the color was changed to gray in both themes.
The contents of the empty view was moved to style.