### PR TITLE
chore(package): update MaidSafe.SafeApp NuGet package and gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# MFractors (Xamarin productivity tool) working folder 
+.mfractor/

--- a/SafeMobileBrowser/SafeMobileBrowser.Android/SafeMobileBrowser.Android.csproj
+++ b/SafeMobileBrowser/SafeMobileBrowser.Android/SafeMobileBrowser.Android.csproj
@@ -58,7 +58,7 @@
       <Version>7.0.35</Version>
     </PackageReference>
     <PackageReference Include="MaidSafe.SafeApp">
-      <Version>0.3.0-rc1</Version>
+      <Version>0.3.0-rc2</Version>
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx">
       <Version>5.0.0</Version>
@@ -67,7 +67,7 @@
       <Version>2.1.0.4</Version>
     </PackageReference>
     <PackageReference Include="Refractored.XamForms.PullToRefresh">
-      <Version>2.4.1.1-beta</Version>
+      <Version>2.5.0.3-beta</Version>
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
       <Version>1.2.0.223</Version>
@@ -75,7 +75,7 @@
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.3.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991265" />
     <PackageReference Include="Xamarin.Android.Support.ViewPager" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
@@ -83,7 +83,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Forms.Visual.Material">
-      <Version>4.3.0.991211</Version>
+      <Version>4.4.0.991265</Version>
     </PackageReference>
     <PackageReference Include="XamEffects">
       <Version>1.6.3</Version>

--- a/SafeMobileBrowser/SafeMobileBrowser.iOS/SafeMobileBrowser.iOS.csproj
+++ b/SafeMobileBrowser/SafeMobileBrowser.iOS/SafeMobileBrowser.iOS.csproj
@@ -123,6 +123,7 @@
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="netstandard" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
@@ -133,13 +134,13 @@
       <Version>7.0.35</Version>
     </PackageReference>
     <PackageReference Include="MaidSafe.SafeApp">
-      <Version>0.3.0-rc1</Version>
+      <Version>0.3.0-rc2</Version>
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx">
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Refractored.XamForms.PullToRefresh">
-      <Version>2.4.1.1-beta</Version>
+      <Version>2.5.0.3-beta</Version>
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
       <Version>1.2.0.223</Version>
@@ -147,9 +148,9 @@
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.3.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991265" />
     <PackageReference Include="Xamarin.Forms.Visual.Material">
-      <Version>4.3.0.991211</Version>
+      <Version>4.4.0.991265</Version>
     </PackageReference>
     <PackageReference Include="XamEffects">
       <Version>1.6.3</Version>

--- a/SafeMobileBrowser/SafeMobileBrowser/Helpers/FileHelper.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/Helpers/FileHelper.cs
@@ -33,7 +33,6 @@ namespace SafeMobileBrowser.Helpers
                 };
 
                 await fileTransferService.TransferAssetsAsync(files);
-                await Session.SetAdditionalSearchPathAsync(fileTransferService.ConfigFilesPath);
                 await Session.InitLoggingAsync($"log-{DateTime.Now:MMddyyyy-HHmm}.log");
                 await Session.SetConfigurationFilePathAsync(fileTransferService.ConfigFilesPath);
                 Logger.Info("Assets transferred");

--- a/SafeMobileBrowser/SafeMobileBrowser/SafeMobileBrowser.csproj
+++ b/SafeMobileBrowser/SafeMobileBrowser/SafeMobileBrowser.csproj
@@ -13,15 +13,15 @@
 
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="7.0.35" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
-    <PackageReference Include="Refractored.XamForms.PullToRefresh" Version="2.4.1.1-beta" />
+    <PackageReference Include="Refractored.XamForms.PullToRefresh" Version="2.5.0.3-beta" />
     <PackageReference Include="Rg.Plugins.Popup" Version="1.2.0.223" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.4.0.991265" />
     <PackageReference Include="XamEffects" Version="1.6.3" />  
-    <PackageReference Include="MaidSafe.SafeApp" Version="0.3.0-rc1" />
+    <PackageReference Include="MaidSafe.SafeApp" Version="0.3.0-rc2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Changes:**
- Updated MaidSafe.SafeApp NuGet package to v0.3.0-RC2.
- Updated packages resolved the iOS app crash issue.
- Removed deprecated API calls and updated them with new API.
- Updated WebFetch login to use `FilesMap` structs, previously we were getting JSON strings.
- Updated `.gitignore` file to not include `mfractor` files in version control.

_**Note:** WebFetch logic not tested with new APIs. Will be done in next PRs._