### PR TITLE
fix/UI: add bottom padding using for iOS and add connecting loading dialog

### DIFF
--- a/SafeMobileBrowser/SafeMobileBrowser/App.xaml.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/App.xaml.cs
@@ -19,6 +19,8 @@ namespace SafeMobileBrowser
 {
     public partial class App : Application
     {
+        public static bool PendingRequest { get; set; }
+
         public static Session AppSession { get; set; }
 
         public static bool IsConnectedToInternet { get; set; }

--- a/SafeMobileBrowser/SafeMobileBrowser/Services/AuthenticationService.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/Services/AuthenticationService.cs
@@ -81,8 +81,12 @@ namespace SafeMobileBrowser.Services
                 {
                     if (decodeResponse is UnregisteredIpcMsg ipcMsg)
                     {
-                        App.AppSession = await Session.AppConnectAsync(Constants.AppId, encodedResponse);
-                        MessagingCenter.Send(this, MessageCenterConstants.Authenticated, encodedResponse);
+                        using (UserDialogs.Instance.Loading(Constants.ConnectingProgressText))
+                        {
+                            App.AppSession = await Session.AppConnectAsync(Constants.AppId, encodedResponse);
+                            App.PendingRequest = false;
+                            MessagingCenter.Send(this, MessageCenterConstants.Authenticated, encodedResponse);
+                        }
                     }
                 }
                 else if (decodedResponseType == typeof(AuthIpcMsg))
@@ -92,6 +96,7 @@ namespace SafeMobileBrowser.Services
                         using (UserDialogs.Instance.Loading(Constants.ConnectingProgressText))
                         {
                             Session session = await Session.AppConnectAsync(Constants.AppId, encodedResponse);
+                            App.PendingRequest = false;
                             AppService.InitialiseSession(session);
                         }
                     }

--- a/SafeMobileBrowser/SafeMobileBrowser/ViewModels/HomePageViewModel.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/ViewModels/HomePageViewModel.cs
@@ -288,7 +288,7 @@ namespace SafeMobileBrowser.ViewModels
             {
                 var result = await Application.Current.MainPage.DisplayAlert(
                                 "Authentication",
-                                "Press authenticate to open authenticator app and authenticate mobile browser.",
+                                "You will be redirected to the authenticator app for authentication.",
                                 "Authenticate",
                                 "Cancel");
                 if (result)

--- a/SafeMobileBrowser/SafeMobileBrowser/Views/HomePage.xaml.cs
+++ b/SafeMobileBrowser/SafeMobileBrowser/Views/HomePage.xaml.cs
@@ -15,6 +15,8 @@ using SafeMobileBrowser.Helpers;
 using SafeMobileBrowser.Models;
 using SafeMobileBrowser.ViewModels;
 using Xamarin.Forms;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace SafeMobileBrowser.Views
 {
@@ -128,6 +130,13 @@ namespace SafeMobileBrowser.Views
         {
             base.OnAppearing();
 
+            if (Device.RuntimePlatform == Device.iOS)
+            {
+                var safeInsets = On<iOS>().SafeAreaInsets();
+                safeInsets.Bottom = 10;
+                Padding = safeInsets;
+            }
+
             if (!_isLogInitialised)
             {
                 _isLogInitialised = await FileHelper.TransferAssetFilesAndInitLoggingAsync();
@@ -139,8 +148,9 @@ namespace SafeMobileBrowser.Views
                 BindingContext = _viewModel;
             }
 
-            if (App.AppSession == null)
+            if (App.AppSession == null && !App.PendingRequest)
             {
+                App.PendingRequest = true;
                 await _viewModel.InitilizeSessionAsync();
 
                 if (!string.IsNullOrWhiteSpace(_launchUrl))


### PR DESCRIPTION
**Changes:**
- Prevent multiple authentication dialogs by using an app-level bool flag.
- Show connection loading dialog so the user knows the process is taking time (needed for the request time out issue).
- Added bottom SafeInsets padding on the iOS so the bottom buttons don't overlap with the iOS navigation indicator.
